### PR TITLE
Small fixes for HTML and naming

### DIFF
--- a/src/app/pages/AdvocatesList/Search.tsx
+++ b/src/app/pages/AdvocatesList/Search.tsx
@@ -18,7 +18,7 @@ const Search = (
 ) => (
   <Stack direction="horizontal" gap={3}>
     <PaddedDiv className="p-1">
-      <FormLabel for={SEARCH_INPUT_NAME}>Search:</FormLabel>
+      <FormLabel htmlFor={SEARCH_INPUT_NAME}>Search:</FormLabel>
     </PaddedDiv>
     <PaddedDiv className="p-1">
       <FormControl name={SEARCH_INPUT_NAME} onChange={onSearch} rows={1} type="textarea" />

--- a/src/app/pages/AdvocatesList/Specialties.tsx
+++ b/src/app/pages/AdvocatesList/Specialties.tsx
@@ -1,6 +1,6 @@
 import AdvocateType, { SpecialtyType } from './types';
 
-const AdvocateRow = ({ specialties }: { specialties: Array<SpecialtyType>; }) => {
+const Specialties = ({ specialties }: { specialties: Array<SpecialtyType>; }) => {
     if (specialties.length === 0) {
         return null;
     }
@@ -16,4 +16,4 @@ const AdvocateRow = ({ specialties }: { specialties: Array<SpecialtyType>; }) =>
     );
 }
 
-export default AdvocateRow;
+export default Specialties;

--- a/src/app/pages/AdvocatesList/Table.tsx
+++ b/src/app/pages/AdvocatesList/Table.tsx
@@ -8,7 +8,7 @@ const TableHead = (props) => (<th className="p-2" {...props} />);
 // TODO: Issue #4 paginate the advocates
 const Table = ({ advocates }: { advocates: Array<AdvocateType> }) => (
   <TableComponent striped bordered hover>
-    <thead>
+    <tr>
       <TableHead>First Name</TableHead>
       <TableHead>Last Name</TableHead>
       <TableHead>City</TableHead>
@@ -16,7 +16,7 @@ const Table = ({ advocates }: { advocates: Array<AdvocateType> }) => (
       <TableHead>Specialties</TableHead>
       <TableHead>Years of Experience</TableHead>
       <TableHead>Phone Number</TableHead>
-    </thead>
+    </tr>
     <tbody>
       {advocates.map((advocate, index) => (
         <TableRow advocate={advocate} key={`advocate_${index}`} />


### PR DESCRIPTION
I noticed these while working on #2

- for instead of htmlFor
- Specialties didn't get renamed when the component did
- thead instead of tr